### PR TITLE
Prepare for Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SUBDIRS=src
-INSTALL_PATH=/usr/local/share/mediasynclite
 RESOURCES_PATH=share/ui/*
+
+# PREFIX is environment variable, but if it is not set, then set default value
+ifeq ($(PREFIX),)
+    PREFIX := /usr
+endif
 
 default: all
 
@@ -13,5 +17,5 @@ clean:
 	@for dir in $(SUBDIRS); do (cd $$dir; $(MAKE) clean); done
 
 install:
-	install -s -D mediasynclite /usr/local/bin
-	@for file in $(RESOURCES_PATH); do (echo "Install: " $$file "to:" $(INSTALL_PATH)/`basename $$file`; if [ -f $$file ]; then install -m 644 -D $$file $(INSTALL_PATH)/`basename $$file`; fi); done
+	install -s -D mediasynclite $(DESTDIR)$(PREFIX)/bin/mediasynclite
+	@for file in $(RESOURCES_PATH); do (echo "Install: " $$file "to:" $(DESTDIR)$(PREFIX)/share/mediasynclite/`basename $$file`; if [ -f $$file ]; then install -m 644 -D $$file $(DESTDIR)$(PREFIX)/share/mediasynclite/`basename $$file`; fi); done

--- a/control
+++ b/control
@@ -1,0 +1,14 @@
+Source: mediasynclite
+Section: multimedia
+Priority: optional
+Maintainer: gilphilbert <gil.philbert@gmail.com>
+Build-Depends: debhelper-compat (= 12), libcurl4-openssl-dev, libgtk-3-dev, gcc, make, libjansson-dev, libssl-dev, openssl
+Standards-Version: 4.4.1
+Homepage: https://github.com/iBroadcastMediaServices/MediaSyncLiteLinux
+#Vcs-Browser: https://salsa.debian.org/debian/mediasynclite
+#Vcs-Git: https://salsa.debian.org/debian/mediasynclite.git
+
+Package: mediasynclite
+Architecture: any
+Depends: openssl, libgtk-3-0
+Description: Upload music from your local machine to iBroadcast cloud

--- a/copyright
+++ b/copyright
@@ -1,0 +1,43 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: mediasynclite
+Upstream-Contact: flagoworld, Rodster001
+Source: https://github.com/iBroadcastMediaServices/MediaSyncLiteLinux
+
+Files: *
+Copyright: <years> <put author's name and email here>
+           <years> <likewise for another author>
+License: <special license>
+ <Put the license of the package here indented by 1 space>
+ <This follows the format of Description: lines in control file>
+ .
+ <Including paragraphs>
+
+# If you want to use GPL v2 or later for the /debian/* files use
+# the following clauses, or change it to suit. Delete these two lines
+Files: debian/*
+Copyright: 2020 iBroadcast <info@ibroadcast.com>
+License: GPL-2+
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
+
+# Please also look if there are files or directories which have a
+# different copyright/license attached and list them here.
+# Please avoid picking licenses with terms that are more restrictive than the
+# packaged work, as it may make Debian's contributions unacceptable upstream.
+#
+# If you need, there are some extra license texts available in two places:
+#   /usr/share/debhelper/dh_make/licenses/
+#   /usr/share/common-licenses/


### PR DESCRIPTION
Packaging this for Debian is fairly straightfoward. I've put some sample files in place although the major changes are to Makefile which needs to respect the $(DESTDIR) environmental variable.

To package: I'm using an Ubuntu system, although this process should apply equally to Debian.

You'll need a GPG key to sign the package. If you don't have one already, use this to generate one. Keep it safe so you can sign future packages.
```
gpg --gen-key
gpg -a --output ~/.gnupg/ibroadcast.gpg --export 'iBroadcast'
gpg --import ~/.gnupg/ibroadcast.gpg
```
Get some prereqs
```
sudo apt-get install build-essential autoconf automake autotools-dev dh-make debhelper devscripts fakeroot xutils lintian pbuilder git
```

Get the source, clone to a specific folder name (project-version)
```
git clone https://github.com/iBroadcastMediaServices/MediaSyncLiteLinux.git mediasynclite-0.4.2
cd mediasynclite-0.4.2
```

Generate the packaging files. Use the same email address you used to create the GPG key
```
dh_make -s -e your@email.com --createorig
```

Move the control and copyright files to the debian folder (you might want to edit these files to make sure the information is correct - for example, dependencies and copyright information)
```
mv control copyright debian/
```

Finally build the .deb file supplying the same email address again:
```
dpkg-buildpackage -rfakeroot -kyour@email.com
```

You'll find the signed .deb package one directory up from your current location. You'll probably want to do a little more work in the debian folder should you want to submit it to the debian repos, but if you're simply looking to distribute it as a prepackaged binary as a release on GitHub, this should work without issue.